### PR TITLE
Burnwire Pin Updates

### DIFF
--- a/firmware/pycubedminiv03/firmware_build/pins.c
+++ b/firmware/pycubedminiv03/firmware_build/pins.c
@@ -22,8 +22,8 @@ STATIC const mp_rom_map_elem_t board_global_dict_table[] = {
     { MP_ROM_QSTR(MP_QSTR_EN_CAM),   MP_ROM_PTR(&pin_PB16)  },
     { MP_ROM_QSTR(MP_QSTR_M_EN),     MP_ROM_PTR(&pin_PB00)  },
     { MP_ROM_QSTR(MP_QSTR_M_FAULT),  MP_ROM_PTR(&pin_PB14)  },
-    { MP_ROM_QSTR(MP_QSTR_BURN1),    MP_ROM_PTR(&pin_PB22)  },
-    { MP_ROM_QSTR(MP_QSTR_BURN2),    MP_ROM_PTR(&pin_PB23)  },
+    { MP_ROM_QSTR(MP_QSTR_BURN1),    MP_ROM_PTR(&pin_PA19)  },
+    { MP_ROM_QSTR(MP_QSTR_BURN2),    MP_ROM_PTR(&pin_PA18)  },
     { MP_ROM_QSTR(MP_QSTR_CS_SD),    MP_ROM_PTR(&pin_PB08)  },
 
     { MP_ROM_QSTR(MP_QSTR_WDT_WDI),  MP_ROM_PTR(&pin_PA23)  },


### PR DESCRIPTION
So we can use board.BURN1 and board.BURN2 in the driver instead of microcontroller.pin.PA19 and microcontroller.pin.PA18

[flight-software issue #74](https://github.com/PyCubed-Mini/flight_software/issues/74)

